### PR TITLE
feat: handle `withCredentials` handling

### DIFF
--- a/src/components/hooks/useVideoDBAgent.js
+++ b/src/components/hooks/useVideoDBAgent.js
@@ -20,9 +20,11 @@ const fetchData = async (rootUrl, endpoint) => {
 };
 
 export function useVideoDBAgent(config) {
-  const { debug = false, socketUrl, httpUrl } = config;
+  const { debug = false, socketUrl, httpUrl, withCredentials } = config;
   if (debug) console.log("debug :videodb-chat config", config);
-  const socket = io(socketUrl);
+  const socket = io(socketUrl, {
+    withCredentials: typeof withCredentials === "boolean" ? withCredentials : true,
+  });
 
   const session = reactive({
     isConnected: false,


### PR DESCRIPTION
## Pull Request

**Description:**
This PR handles the configuration of the `withCredentials` property for socket connection. This property allows sending cookies to cross-site requests, which by default, is set to `false` 

**Changes:**
- [x] Added `withCredentials` as a part of the config 


**Related Issues:**
none

**Testing:**
- passed in `withCredentials` property as true or false


**Checklist:**
- [x] Code follows project coding standards
- [ ] Tests have been added or updated
- [ ] Code Review
- [ ] Manual test after merge
- [ ] All checks passed