### PR TITLE
feat: join session rooms for reconnectivity

### DIFF
--- a/src/components/hooks/useVideoDBAgent.js
+++ b/src/components/hooks/useVideoDBAgent.js
@@ -51,6 +51,13 @@ export function useVideoDBAgent(config) {
   const activeCollectionImages = ref(null);
   const activeImageData = ref(null);
 
+  const setActiveSession = (sessionId) => {
+    session.sessionId = sessionId;
+    if (session.isConnected && session.sessionId) {
+      socket.emit("join_session", { session_id: session.sessionId });
+    }
+  };
+
   const fetchSession = async (sessionId) =>
     fetchData(httpUrl, `/session/${sessionId}`);
   const fetchSessions = async () => fetchData(httpUrl, "/session");
@@ -274,7 +281,7 @@ export function useVideoDBAgent(config) {
       fetchPastMessages = false;
     }
     if (debug) console.log("debug :videodb-chat session loading", sessionId);
-    session.sessionId = sessionId;
+    setActiveSession(sessionId);
     if (!fetchPastMessages) {
       Object.keys(conversations).forEach((key) => delete conversations[key]);
     } else {
@@ -575,6 +582,9 @@ export function useVideoDBAgent(config) {
   socket.on("connect", () => {
     if (debug) console.log("debug :videodb-chat socket emmited connect");
     session.isConnected = true;
+    if (session.sessionId) {
+      socket.emit("join_session", { session_id: session.sessionId });
+    }
   });
 
   socket.on("chat", (event) => {
@@ -608,6 +618,14 @@ export function useVideoDBAgent(config) {
       }
     }
   });
+
+  if (typeof document !== "undefined" && typeof window !== "undefined") {
+    document.addEventListener("visibilitychange", () => {
+      if (!document.hidden && session.sessionId && session.isConnected) {
+        socket.emit("join_session", { session_id: session.sessionId });
+      }
+    });
+  }
 
   return {
     ...toRefs(session),

--- a/src/components/hooks/useVideoDBAgent.js
+++ b/src/components/hooks/useVideoDBAgent.js
@@ -573,7 +573,6 @@ export function useVideoDBAgent(config) {
         ...message,
       };
 
-      conversations[convId] = { [msgId]: _message };
       socket.emit("chat", _message);
       addClientLoadingMessage(convId);
     }
@@ -588,15 +587,21 @@ export function useVideoDBAgent(config) {
   });
 
   socket.on("chat", (event) => {
-    if (debug) console.log("debug :videodb-chat socket emmited chat", event);
+    if (debug) console.log("debug :videodb-chat socket received chat", event);
     if (session.sessionId !== event.session_id) return;
+
     if (session.isConnected) {
       const { conv_id: convId, msg_id: msgId } = event;
       if (!conversations[convId]) {
         conversations[convId] = {};
       }
-      conversations[convId][msgId] = { sender: "assistant", ...event };
-      removeClientLoadingMessage(convId);
+
+      const sender = event.msg_type === "input" ? "user" : "assistant";
+      conversations[convId][msgId] = { sender, ...event };
+
+      if (event.msg_type === "output") {
+        removeClientLoadingMessage(convId);
+      }
     }
   });
 


### PR DESCRIPTION
## Pull Request

**Description:**
This PR handles the session reconnection update from VideoDB Director

**Previous experience**
- When the frontend used to connection to the backend via the socketio connection, socketio used to assign a unique internal Session ID, which helps backend track which client to send the message
- **Problem**: If the client reloads the page, closes the tab accidentally, loses connection, or simply checks the currently running agent invocation on a different device, the user will not be able to see the live updates. This is crucial for long running tasks

**Changes:**
- [x] Adds `join_session` message handling and requests to allow joining a message room which maintains the conversation between FE and BE

**Related Issues:**


**Testing:**



**Checklist:**
- [x] Code follows project coding standards
- [ ] Tests have been added or updated
- [ ] Code Review
- [ ] Manual test after merge
- [ ] All checks passed